### PR TITLE
overriden apiUrl to working one

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -54,7 +54,8 @@ module.exports = {
       new GoogleFontsPlugin({
         fonts: [
           { family: 'Ubuntu', variants: ['300', '400'] }
-        ]
+        ],
+        apiUrl: "https://gwfh.mranftl.com/api/fonts"
       })
     ]
   }


### PR DESCRIPTION
Fix for #50 

apiUrl changed to one prescribed by owner of previous api at https://google-webfonts-helper.herokuapp.com/api/fonts