### PR TITLE
Fix for fake "We couldn't connect to any WebTorrent trackers" message.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -217,8 +217,8 @@ export default {
       let warningMsg = false
 
       p2pt.on('trackerwarning', (error, stats) => {
-        warningCount++
-        console.log(error)
+        if (error.message.includes('connection error to ws')) warningCount++
+        console.warn(error)
 
         if (warningCount >= stats.total && !trackerConnected && !warningMsg) {
           warningMsg = this.$buefy.snackbar.open({


### PR DESCRIPTION
The point is that the warningCount records the number of all errors, not just connection-related errors (which is what the "warningCount >= stats.total" logic was designed for)